### PR TITLE
DynaClassLoader enhancement for class loading in different assemblies

### DIFF
--- a/src/Vlingo.Common.Tests/Compiler/DynaClassLoaderTest.cs
+++ b/src/Vlingo.Common.Tests/Compiler/DynaClassLoaderTest.cs
@@ -58,10 +58,29 @@ namespace Vlingo.Common.Tests.Compiler
             var actorDynaClass = classLoader.LoadClass("Vlingo.Common.Compiler.DynaFile");
             Assert.NotNull(actorDynaClass);
         }
+        
+        [Fact]
+        public void TestLoadImplementationDifferentNamespace()
+        {
+            var protocolName = typeof(IRunnable);
+            var classLoader = new DynaClassLoader();
+            
+            // Vlingo.Common.Runnable__Proxy is what is being called if the interface is implemented in
+            // different namespace than the implementation.
+            var dynaNamingClassType = classLoader.LoadClass("Vlingo.Common.Runnable__Proxy", protocolName);
+            Assert.NotNull(dynaNamingClassType);
+        }
     }
 
     public interface ITestInterface
     {
         int Test();
+    }
+    
+    public class Runnable__Proxy : IRunnable
+    {
+        public void Run()
+        {
+        }
     }
 }

--- a/src/Vlingo.Common/Vlingo.Common.csproj
+++ b/src/Vlingo.Common/Vlingo.Common.csproj
@@ -5,7 +5,7 @@
     
     <!-- NuGet Metadata -->
     <IsPackable>true</IsPackable>
-    <PackageVersion>0.4.0</PackageVersion>
+    <PackageVersion>0.4.1</PackageVersion>
     <PackageId>Vlingo.Common</PackageId>
     <Authors>Vlingo</Authors>
     <Description>


### PR DESCRIPTION
This PR allows to load implementing class from a different assembly than requested interface namespace the class is implementing.

This fixes the following scenario we have currently in `Vlingo.Wire`:
- `IScheduled` interface is in the assembly `Vlingo.Common`
- its implementation `Scheduled__Proxy` is in assembly `Vlingo.Actors`
- When the proxy is requested in `Vlingo.Wire` the requested protocol is `Vlingo.Common.Scheduled__Proxy` which obviously cannot be found by the current implementation.

This implementation allows to load `Vlingo.Actors.Scheduled__Proxy` if not found in `Vlingo.Common` namespace and if the `Vlingo.Common.Scheduled__Proxy` is requested. It finds candidates types like `Vlingo.Actors.Scheduled__Proxy` and checks that it really implements the interface `Vlingo.Common.IScheduled`

This behavior is different from the java implementation where I cannot observe the same bug.