### PR TITLE
Loading calling assembly reference before proxy compilation

### DIFF
--- a/src/Vlingo.Common/Compiler/DynaCompiler.cs
+++ b/src/Vlingo.Common/Compiler/DynaCompiler.cs
@@ -35,6 +35,7 @@ namespace Vlingo.Common.Compiler
                 {
                     typeof(object).GetTypeInfo().Assembly,
                     input.Protocol.GetTypeInfo().Assembly,
+                    Assembly.GetCallingAssembly(),
                     Assembly.Load(new AssemblyName("mscorlib")),
                     Assembly.Load(new AssemblyName("netstandard")),
                 };

--- a/src/Vlingo.Common/Vlingo.Common.csproj
+++ b/src/Vlingo.Common/Vlingo.Common.csproj
@@ -5,7 +5,7 @@
     
     <!-- NuGet Metadata -->
     <IsPackable>true</IsPackable>
-    <PackageVersion>0.4.5</PackageVersion>
+    <PackageVersion>0.4.6</PackageVersion>
     <PackageId>Vlingo.Common</PackageId>
     <Authors>Vlingo</Authors>
     <Description>


### PR DESCRIPTION
In some cases `Vlingo.Actors` reference is not loaded before proxy compilation so the compilation fails. This should fix the one part of the issue referenced in Actors https://github.com/vlingo-net/vlingo-net-actors/issues/40