### PR TITLE
Cancelling the background task when stopping AsyncMessageQueue

### DIFF
--- a/src/Vlingo.Common/Message/AsyncMessageQueue.cs
+++ b/src/Vlingo.Common/Message/AsyncMessageQueue.cs
@@ -59,7 +59,14 @@ namespace Vlingo.Common.Message
 
                 cancellationSource.Cancel();
                 taskProcessedEvent.Set();
-                backgroundWorker.Wait(cancellationSource.Token);
+                try
+                {
+                    backgroundWorker.Wait(cancellationSource.Token);
+                }
+                catch (OperationCanceledException e)
+                {
+                    // TODO: log or do nothing but everything is ok
+                }
             }
             Dispose(true);
         }

--- a/src/Vlingo.Common/Message/AsyncMessageQueue.cs
+++ b/src/Vlingo.Common/Message/AsyncMessageQueue.cs
@@ -24,6 +24,7 @@ namespace Vlingo.Common.Message
         private readonly CancellationTokenSource cancellationSource;
         private readonly AutoResetEvent taskProcessedEvent;
         private readonly AutoResetEvent endDispatchingEvent;
+        private readonly Task backgroundWorker;
 
         public AsyncMessageQueue()
             : this(null)
@@ -40,7 +41,7 @@ namespace Vlingo.Common.Message
             taskProcessedEvent = new AutoResetEvent(false);
             endDispatchingEvent = new AutoResetEvent(false);
             cancellationSource = new CancellationTokenSource();
-            Task.Run(() => TaskAction(), cancellationSource.Token);
+            backgroundWorker = Task.Run(() => TaskAction(cancellationSource.Token), cancellationSource.Token);
         }
 
         public virtual void Close() => Close(true);
@@ -58,6 +59,7 @@ namespace Vlingo.Common.Message
 
                 cancellationSource.Cancel();
                 taskProcessedEvent.Set();
+                backgroundWorker.Wait(cancellationSource.Token);
             }
             Dispose(true);
         }
@@ -160,9 +162,9 @@ namespace Vlingo.Common.Message
             return null;
         }
 
-        private void TaskAction()
+        private void TaskAction(CancellationToken token)
         {
-            while (!cancellationSource.IsCancellationRequested)
+            while (!token.IsCancellationRequested)
             {
                 taskProcessedEvent.WaitOne();
                 while (!queue.IsEmpty)


### PR DESCRIPTION
To be sure we're cleaning properly a background task in `AsyncMessageQueue` I'm making sure then when closing the underlying task is cancelled as well. This solves issue #33 